### PR TITLE
i18n: load translation files for JS

### DIFF
--- a/register.php
+++ b/register.php
@@ -82,3 +82,22 @@ foreach ( array(
         'type' => 'string',
     ) );
 }
+
+wp_register_script(
+	'slide',
+	plugins_url( 'index.js', __FILE__ ),
+	array( 'wp-i18n' ),
+	filemtime( dirname( __FILE__ ) . '/index.js' )
+);
+
+wp_register_script(
+	'slide-template',
+	plugins_url( 'template.js', __FILE__ ),
+	array( 'wp-i18n' ),
+	filemtime( dirname( __FILE__ ) . '/template.js' )
+);
+
+if ( function_exists( 'wp_set_script_translations' ) ) {
+	wp_set_script_translations( 'slide', 'slide' );
+	wp_set_script_translations( 'slide-template', 'slide' );
+}


### PR DESCRIPTION
Block menu texts are not translated as below image (French).

Though there are translation files of French and Japanese in mo and JSON format, almost all texts are not translated except "Presentation Cover Image" menu that was translated in PHP side (register.php). See bottom of the 1st image.

We need invoke `wp_register_script()` and `wp_set_script_translations()` to load translation file of JSON format for JavaScript sources. See 2nd image for applied result.

before fix:
<img width="299" alt="slide-before-fix" src="https://user-images.githubusercontent.com/8876600/71570064-a70ad000-2b16-11ea-87ca-9604567e5530.png">

after fix:
<img width="289" alt="slide-after-fix" src="https://user-images.githubusercontent.com/8876600/71570168-bee25400-2b16-11ea-9f08-da8dba66143d.png">



