### PR TITLE
Experimental: add an export npm script

### DIFF
--- a/bin/export.js
+++ b/bin/export.js
@@ -1,0 +1,36 @@
+const fsp = require("fs").promises;
+const path = require("path");
+const puppeteer = require("puppeteer");
+
+if (process.argv.length !== 4) {
+  console.error("Usage: npm run export [url] [output-dir]");
+  process.exit(1);
+}
+
+let url = process.argv[2];
+const outputDirectory = process.argv[3];
+
+(async () => {
+  await fsp.mkdir(outputDirectory, { recursive: true });
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1920, height: 1080 });
+  let goingOn = true;
+  let slide = 1;
+  console.log(`▶️  Exporting all slides to ${outputDirectory}`);
+  await page.goto(url);
+  while (goingOn) {
+    const paddedSlide =
+      "0".repeat(2 - Math.floor(Math.log10(slide))) + slide.toString();
+    console.log(`   📸 Exporting slide ${slide}…`);
+    await page.screenshot({
+      path: path.join(outputDirectory, `slide${paddedSlide}.png`)
+    });
+    slide++;
+    await page.keyboard.press("Space");
+    goingOn = url !== page.url();
+    url = page.url();
+  }
+  await browser.close();
+  console.log("✅ Done");
+})();


### PR DESCRIPTION
Quite hacky at this point, though the script was successfully used to export few presentations I had.

Approach: uses puppeteer to open a URL and press Space, while taking
screenshots. We assume that at each transition the URL changes. Once it
stops changing, we assume there are no more slides.

Plenty of problems:
- requires `node`;
- assumes that the URL is visible without authentication and from the environment we are running the script from (there can be proxies, etc.);
- no error handling – not sure what will happen if something breaks;
- the assumption that the URL will change quickly enough is weak, I can see how it either finish too early or lead to an infinite loop. Knowing the number of slides in advance will be better;
- assumes we have less than 1000 slides, so that we can take care of padding in file names. Seems the safest assumption compared to the ones above :) Can be lifted if we know the number of slides in advance;
- Used local `prettier` rules, didn't setup the WordPress rules for now;
- Resolution is hard-coded at Full HD – 1920:1080. Quite typical projector resolution these days.

I am posting more to start discussion and as a starting point than an attempt to merge it. Also curious how did you handle exporting State of the Word presentation.